### PR TITLE
Implemented the services to list packages, their license and fetch license content.

### DIFF
--- a/LicenseManagementAssistants.js
+++ b/LicenseManagementAssistants.js
@@ -17,17 +17,72 @@
  *
  */
 
+if(typeof require === 'undefined') {
+   require = IMPORTS.require;
+}
+
+if(typeof licensesRoot === 'undefined') {
+   licensesRoot = '/usr/share/licenses';
+}
+
+
+fs = require('fs');
+
+var ListPackagesAssistant = function() { }
 var ListLicensesForPackageAssistant = function() { }
-var GetLicenseForPackageAssistant = function() { }
+var GetLicenseTextForPackageAssistant = function() { }
+
+ListPackagesAssistant.prototype.run = function(future) {
+	
+	var contents = fs.readdirSync(licensesRoot);
+
+	var packages = [];
+
+	for (var i = 0; i < contents.length; i++) {
+	    var fileInfo = fs.statSync(licensesRoot + "/" + contents[i]);
+	    if (fileInfo.isDirectory()) {
+	        packages.push(contents[i]);
+	    } 
+	}
+	
+    future.result = {
+        "returnValue": true,
+        "packages": packages
+    };
+}
 
 ListLicensesForPackageAssistant.prototype.run = function(future) {
+	var args = this.controller.args;
+
+	var packageLicenseRoot = licensesRoot + "/" + args.package;
+	var contents = fs.readdirSync(packageLicenseRoot);
+
+	var licenses = [];
+
+	for (var i = 0; i < contents.length; i++) {
+	    var fileInfo = fs.statSync(packageLicenseRoot + "/" + contents[i]);
+	    if (fileInfo.isFile()) {
+	        licenses.push(contents[i]);
+	    } 
+	}
+
     future.result = {
         "returnValue": true,
+        "licenses": licenses
     };
 }
 
-GetLicenseForPackageAssistant.prototype.run = function(future) {
+
+GetLicenseTextForPackageAssistant.prototype.run = function(future) {
+	var args = this.controller.args;
+
+	var licenseFile = licensesRoot + "/" + args.package + "/" + args.license;
+
+	var license = fs.readFileSync(licenseFile,'utf8');
+
     future.result = {
         "returnValue": true,
+        "license": license
     };
 }
+

--- a/services.json
+++ b/services.json
@@ -7,13 +7,18 @@
         "description": "License management service",
         "commands": [
             {
+                "name": "listPackages",
+                "assistant": "ListPackagesAssistant",
+                "public": true
+            },
+            {
                 "name": "listLicensesForPackage",
                 "assistant": "ListLicensesForPackageAssistant",
                 "public": true
             },
             {
-                "name": "GetLicenseForPackage",
-                "assistant": "GetLicenseForPackageAssistant",
+                "name": "getLicenseTextForPackage",
+                "assistant": "GetLicenseTextForPackageAssistant",
                 "public": true
             }
         ]


### PR DESCRIPTION
Implemented the 3 license services. Tested using luna-send on the Ports Emulator
- listPackages
  
  luna-send -n 1 palm://org.webosports.service.licenses/listPackages '{}'

List directories in /usr/share/licenses
- listLicensesForPackage

luna-send -n 1 palm://org.webosports.service.licenses/listLicensesForPackage '{"package": "luna-service2"}'

List files in the  /usr/share/licenses/luna-service2
- getLicenseTextForPackage 

luna-send -n 1 palm://org.webosports.service.licenses/getLicenseTextForPackage '{"package": "luna-service2", "license": "Apache-2.0"}'

File content of /usr/share/licenses/"luna-service2/Apache-2.0
