### PR TITLE
Changed License Text service to return byte array instead of String to a...

### DIFF
--- a/LicenseManagementAssistants.js
+++ b/LicenseManagementAssistants.js
@@ -78,7 +78,9 @@ GetLicenseTextForPackageAssistant.prototype.run = function(future) {
 
 	var licenseFile = licensesRoot + "/" + args.package + "/" + args.license;
 
-	var license = fs.readFileSync(licenseFile,'utf8');
+	// This returns a byte array. If we encode this to a string, we need to escape special characters
+	// to be able to JSON encode it. So we pass data as a byte array and covert it to a string in the client
+	var license = fs.readFileSync(licenseFile);
 
     future.result = {
         "returnValue": true,


### PR DESCRIPTION
Changed the License Text service to return a byte array to avoid running into JSON encoding issues when ServiceRequest.js kind try to convert the results to JSON. The client is now changed to perform the encoding instead. 
