### PR TITLE
org.webosports.service.licenses: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/org.webosports.service.licenses.api.json
+++ b/files/sysbus/org.webosports.service.licenses.api.json
@@ -1,5 +1,5 @@
 {
-    "settings": [
+    "license-service.operation": [
         "org.webosports.service.licenses/listPackages",
         "org.webosports.service.licenses/listLicensesForPackage",
         "org.webosports.service.licenses/getLicenseTextForPackage"

--- a/files/sysbus/org.webosports.service.licenses.perm.json
+++ b/files/sysbus/org.webosports.service.licenses.perm.json
@@ -1,6 +1,6 @@
 {
     "org.webosports.service.licenses": [
-        "settings",
-        "activities.manage"
+        "activity.operation",
+        "license-service.operation"        
     ]
 }

--- a/files/sysbus/org.webosports.service.licenses.role.json
+++ b/files/sysbus/org.webosports.service.licenses.role.json
@@ -1,6 +1,7 @@
 {
     "appId": "org.webosports.service.licenses",
     "allowedNames": ["org.webosports.service.licenses"],
+    "trustLevel" : "oem",
     "type": "regular",
     "permissions": [
         {


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
